### PR TITLE
Solving ReferenceError: req is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -596,7 +596,7 @@ var Session = function (target, community, options) {
 	this.dgram.on ("error", me.onError.bind (me));
 
 	if (this.sourceAddress || this.sourcePort)
-		req.dgram.bind (this.sourcePort, this.sourceAddress);
+		this.dgram.bind (this.sourcePort, this.sourceAddress);
 };
 
 util.inherits (Session, events.EventEmitter);


### PR DESCRIPTION
**I replaced req.dgram.bind with this.dgram.bind** because when calling the createSession method, it creates a new Session object and it crashes with an error such as:

c:\Snmp-Test\node_modules\net-snmp\index.js:599
		req.dgram.bind (this.sourcePort, this.sourceAddress);
		^

ReferenceError: req is not defined
    at new Session (c:\ANF\Asintel.Spi-Snmp\node_modules\net-snmp\index.js:599:3)
    at Object.exports.createSession (c:\ANF\Asintel.Spi-Snmp\node_modules\net-snmp\index.js:1440:9)
    at Object.<anonymous> (c:\ANF\Asintel.Spi-Snmp\src\trap.js:16:20)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (c:\ANF\Asintel.Spi-Snmp\index.js:5:1)
