### PR TITLE
Add support of 16bit ids to help interoperate with older devices.

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,8 @@ The `createSession()` function instantiates and returns an instance of the
         timeout: 5000,
         transport: "udp4",
         trapPort: 162,
-        version: snmp.Version1
+        version: snmp.Version1,
+        idBitsSize: 16
     };
     
     var session = snmp.createSession ("127.0.0.1", "public", options);
@@ -353,6 +354,8 @@ is an object, and can contain the following items:
  * `trapPort` - UDP port to send traps and informs too, defaults to `162`
  * `version` - Either `snmp.Version1` or `snmp.Version2c`, defaults to
    `snmp.Version1`
+ * `idBitsSize` - Either `16` or `32`, defaults to `32`.  Used to reduce the size
+    of the generated id for compatibility with some older devices.
 
 ## session.on ("close", callback)
 

--- a/index.js
+++ b/index.js
@@ -577,6 +577,10 @@ var Session = function (target, community, options) {
 			? parseInt(options.sourcePort)
 			: undefined;
 
+	this.idBitsSize = (options && options.idBitsSize)
+			? parseInt(options.idBitsSize)
+			: 32;
+
 	this.reqs = {};
 	this.reqCount = 0;
 
@@ -608,8 +612,11 @@ Session.prototype.cancelRequests = function (error) {
 	}
 };
 
-function _generateId () {
-	return Math.floor (Math.random () + Math.random () * 10000000)
+function _generateId (bitsSize) {
+	if (bitSize === 16) {
+		return Math.floor(Math.random() * 0x10000);
+	}
+	return Math.floor(Math.random() * 0x100000000);
 }
 
 Session.prototype.get = function (oids, responseCb) {
@@ -1043,7 +1050,7 @@ Session.prototype.simpleGet = function (pduClass, feedCb, varbinds,
 	var req = {};
 
 	try {
-		var id = _generateId ();
+		var id = _generateId (this.idBitsSize);
 		var pdu = new pduClass (id, varbinds, options);
 		var message = new RequestMessage (this.version, this.community, pdu);
 
@@ -1289,7 +1296,7 @@ Session.prototype.trap = function () {
 			pduVarbinds.push (varbind);
 		}
 		
-		var id = _generateId ();
+		var id = _generateId (this.idBitsSize);
 
 		if (this.version == Version2c) {
 			if (typeof typeOrOid != "string")

--- a/test/varbinds.js
+++ b/test/varbinds.js
@@ -1,5 +1,5 @@
 
-var ber    = require ("asn1").Ber;
+var ber    = require ('asn1-ber').Ber;
 var assert = require('assert');
 var snmp   = require('../');
 


### PR DESCRIPTION
This should help address #21, some older devices don't support 32 bit ids, it's somewhat common to see devices only handle 16 bit ids.  The C net-snmp solves this with the `--16bitIDs=1` flag.  I tried to follow that pattern.